### PR TITLE
Add description field and admin UI

### DIFF
--- a/assistants/admin.py
+++ b/assistants/admin.py
@@ -1,3 +1,15 @@
 from django.contrib import admin
+from .models import Assistant, Message
 
-# Register your models here.
+
+@admin.register(Assistant)
+class AssistantAdmin(admin.ModelAdmin):
+    list_display = ("name", "description", "created_at")
+    readonly_fields = ("openai_id", "thread_id", "created_at")
+    fields = ("name", "description", "instructions", "tools", "openai_id", "thread_id", "created_at")
+
+
+@admin.register(Message)
+class MessageAdmin(admin.ModelAdmin):
+    list_display = ("assistant", "role", "created_at")
+    readonly_fields = ("created_at",)

--- a/assistants/migrations/0003_assistant_description.py
+++ b/assistants/migrations/0003_assistant_description.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('assistants', '0002_assistant_openai_id_assistant_thread_id'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='assistant',
+            name='description',
+            field=models.TextField(blank=True),
+        ),
+    ]
+

--- a/assistants/models.py
+++ b/assistants/models.py
@@ -8,6 +8,7 @@ from django.db import models
 class Assistant(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     name = models.CharField(max_length=120)
+    description = models.TextField(blank=True)
     instructions = models.TextField(blank=True)
     tools = models.JSONField(default=list, help_text="e.g. ['code_interpreter']")
     created_at = models.DateTimeField(auto_now_add=True)

--- a/assistants/serializers.py
+++ b/assistants/serializers.py
@@ -18,5 +18,5 @@ class AssistantSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Assistant
-        fields = ['id', 'name', 'instructions', 'tools', 'created_at', 'messages']
+        fields = ['id', 'name', 'description', 'instructions', 'tools', 'created_at', 'messages']
         read_only_fields = ['id', 'created_at']

--- a/assistants/views.py
+++ b/assistants/views.py
@@ -75,6 +75,7 @@ class AssistantViewSet(viewsets.ModelViewSet):
         serializer.save(
             openai_id=oa_asst.id,
             tools=tools,
+            description=data.get("description") or "",
         )
 
 


### PR DESCRIPTION
## Summary
- add `description` field to `Assistant`
- allow description in API serializer and create logic
- register `Assistant` and `Message` in Django admin
- add migration for new field

## Testing
- `pytest -q` *(fails: no tests configured)*
- `python3 manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*