### PR TITLE
Add chat history endpoint

### DIFF
--- a/assistants/tests.py
+++ b/assistants/tests.py
@@ -1,3 +1,20 @@
+from django.urls import reverse
+from rest_framework.test import APIClient
+from rest_framework import status
 from django.test import TestCase
+from .models import Assistant, Message
 
-# Create your tests here.
+
+class ChatHistoryTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.asst = Assistant.objects.create(name="tester")
+        Message.objects.create(assistant=self.asst, role="user", content="hi")
+        Message.objects.create(assistant=self.asst, role="assistant", content="hello")
+
+    def test_history_endpoint_returns_messages(self):
+        url = reverse('chat-history', args=[self.asst.pk])
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(resp.data), 2)
+

--- a/assistants/urls.py
+++ b/assistants/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
-from .views import AssistantViewSet, MessageViewSet, ChatView
+from .views import AssistantViewSet, MessageViewSet, ChatView, ChatHistoryView
 
 router = DefaultRouter()
 router.register('assistants', AssistantViewSet, basename='assistant')
@@ -9,4 +9,5 @@ router.register('messages',   MessageViewSet,   basename='message')
 urlpatterns = [
     path('', include(router.urls)),
     path('assistants/<uuid:pk>/chat/', ChatView.as_view(), name='chat'),
+    path('assistants/<uuid:pk>/history/', ChatHistoryView.as_view(), name='chat-history'),
 ]

--- a/assistants/views.py
+++ b/assistants/views.py
@@ -156,3 +156,13 @@ class ChatView(APIView):
 
         # 🔹 8.  Return a normal JSON response
         return JsonResponse({"content": assistant_msg})
+
+
+class ChatHistoryView(APIView):
+    """Return entire chat history for a given assistant."""
+
+    def get(self, request, pk):
+        assistant = get_object_or_404(Assistant, pk=pk)
+        messages = assistant.messages.all()
+        serializer = MessageSerializer(messages, many=True)
+        return Response(serializer.data)


### PR DESCRIPTION
## Summary
- add `ChatHistoryView` to fetch all chat messages for an assistant
- wire new view into `urls.py`
- add tests for the history endpoint

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*