### PR TITLE
Restrict assistant model choices

### DIFF
--- a/assistants/models.py
+++ b/assistants/models.py
@@ -4,6 +4,11 @@ SQLite-backed models for assistants and their messages.
 import uuid
 from django.db import models
 
+# ─────────────────────────────────────────────────────────────────────────────
+#  Allowed assistant models
+# ─────────────────────────────────────────────────────────────────────────────
+ALLOWED_MODELS = ["gpt-4", "gpt-4o", "o1-mini", "o3-mini"]
+
 
 class Assistant(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
@@ -11,7 +16,8 @@ class Assistant(models.Model):
     description = models.TextField(blank=True)
     instructions = models.TextField(blank=True)
     tools = models.JSONField(default=list, help_text="e.g. ['code_interpreter']")
-    model = models.CharField(max_length=40, default="gpt-4o")
+    MODEL_CHOICES = [(m, m) for m in ALLOWED_MODELS]
+    model = models.CharField(max_length=40, default="gpt-4o", choices=MODEL_CHOICES)
     created_at = models.DateTimeField(auto_now_add=True)
     openai_id  = models.CharField(max_length=40, blank=True, null=True)  # asst_…
     thread_id  = models.CharField(max_length=40, blank=True, null=True)  # thr_…

--- a/assistants/serializers.py
+++ b/assistants/serializers.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from .models import Assistant, Message
+from .models import Assistant, Message, ALLOWED_MODELS
 
 
 class MessageSerializer(serializers.ModelSerializer):
@@ -13,7 +13,7 @@ class AssistantSerializer(serializers.ModelSerializer):
     tools = serializers.ListField(child=serializers.CharField(),
                                   required=False,  # allow it to be omitted
                                   default=list)
-    model = serializers.CharField(default="gpt-4o")
+    model = serializers.ChoiceField(choices=ALLOWED_MODELS, default="gpt-4o")
 
     messages = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
 

--- a/assistants/tests.py
+++ b/assistants/tests.py
@@ -46,12 +46,28 @@ class CreateAssistantModelTests(TestCase):
         with patch.dict(sys.modules, {'openai': dummy_openai}):
             resp = self.client.post('/api/assistants/', {
                 'name': 'Test',
-                'model': 'gpt-3.5-turbo',
+                'model': 'gpt-4',
             }, format='json')
 
         self.assertEqual(resp.status_code, 201)
         asst = Assistant.objects.get(name='Test')
-        self.assertEqual(asst.model, 'gpt-3.5-turbo')
+        self.assertEqual(asst.model, 'gpt-4')
+
+    def test_create_assistant_invalid_model_fails(self):
+        class DummyClient:
+            def __init__(self):
+                self.beta = types.SimpleNamespace(assistants=types.SimpleNamespace(create=MagicMock()))
+                self.files = types.SimpleNamespace(create=MagicMock())
+
+        dummy_openai = types.SimpleNamespace(OpenAI=lambda api_key=None: DummyClient())
+
+        with patch.dict(sys.modules, {'openai': dummy_openai}):
+            resp = self.client.post('/api/assistants/', {
+                'name': 'TestBad',
+                'model': 'gpt-3.5-turbo',
+            }, format='json')
+
+        self.assertEqual(resp.status_code, 400)
 
 
 class UpdateAssistantTests(TestCase):


### PR DESCRIPTION
## Summary
- enforce allowed models for the `Assistant` model and serializer
- update tests for new choices and add validation failure case

## Testing
- `pytest assistants/tests.py -q` *(fails: ModuleNotFoundError: No module named 'django')*