### PR TITLE
Implement assistant thread reset feature

### DIFF
--- a/assistants/urls.py
+++ b/assistants/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
-from .views import AssistantViewSet, MessageViewSet, ChatView
+from .views import AssistantViewSet, MessageViewSet, ChatView, ResetThreadView
 
 router = DefaultRouter()
 router.register('assistants', AssistantViewSet, basename='assistant')
@@ -9,4 +9,5 @@ router.register('messages',   MessageViewSet,   basename='message')
 urlpatterns = [
     path('', include(router.urls)),
     path('assistants/<uuid:pk>/chat/', ChatView.as_view(), name='chat'),
+    path('assistants/<uuid:pk>/reset/', ResetThreadView.as_view(), name='reset'),
 ]


### PR DESCRIPTION
## Summary
- document new /api/assistants/<id>/reset/ endpoint
- add `ResetThreadView` API view to delete an assistant's thread and messages
- expose the reset endpoint in URL routing
- test that resetting the thread clears messages and calls OpenAI API

## Testing
- `python manage.py test -v 2` *(fails: ModuleNotFoundError: No module named 'django')*