### PR TITLE
Fix message endpoint filtering

### DIFF
--- a/assistants/tests.py
+++ b/assistants/tests.py
@@ -240,3 +240,19 @@ class ResetThreadTests(TestCase):
         delete_mock.assert_called_with('thr_123')
 
 
+class MessageFilterTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.asst1 = Assistant.objects.create(name='A1')
+        self.asst2 = Assistant.objects.create(name='A2')
+        Message.objects.create(assistant=self.asst1, role='user', content='hi1')
+        Message.objects.create(assistant=self.asst2, role='user', content='hi2')
+
+    def test_filter_by_assistant(self):
+        resp = self.client.get('/api/messages/', {'assistant': self.asst1.id})
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]['assistant'], str(self.asst1.id))
+
+

--- a/assistants/views.py
+++ b/assistants/views.py
@@ -123,8 +123,15 @@ class AssistantViewSet(viewsets.ModelViewSet):
 #  Messages (read-only)
 # ──────────────────────────────────────────────────────────────────────────────
 class MessageViewSet(viewsets.ReadOnlyModelViewSet):
-    queryset = Message.objects.all()
     serializer_class = MessageSerializer
+
+    def get_queryset(self):
+        """Optionally filter messages by assistant via ?assistant=<uuid>."""
+        qs = Message.objects.all()
+        asst_id = self.request.query_params.get("assistant")
+        if asst_id:
+            qs = qs.filter(assistant_id=asst_id)
+        return qs
 
 
 # ──────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- filter `MessageViewSet` by assistant ID when query parameter provided
- add tests to verify filtering works

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*