### PR TITLE
Add vector store update support

### DIFF
--- a/assistants/migrations/0006_assistant_vector_store_id.py
+++ b/assistants/migrations/0006_assistant_vector_store_id.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('assistants', '0005_assistant_reasoning_effort'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='assistant',
+            name='vector_store_id',
+            field=models.CharField(max_length=40, blank=True, null=True),
+        ),
+    ]

--- a/assistants/models.py
+++ b/assistants/models.py
@@ -31,8 +31,9 @@ class Assistant(models.Model):
         default="medium",
     )
     created_at = models.DateTimeField(auto_now_add=True)
-    openai_id  = models.CharField(max_length=40, blank=True, null=True)  # asst_…
-    thread_id  = models.CharField(max_length=40, blank=True, null=True)  # thr_…
+    openai_id  = models.CharField(max_length=40, blank=True, null=True)  # asst_...
+    thread_id  = models.CharField(max_length=40, blank=True, null=True)  # thr_...
+    vector_store_id = models.CharField(max_length=40, blank=True, null=True)
 
     def __str__(self) -> str:
         return self.name


### PR DESCRIPTION
## Summary
- store vector store id on `Assistant`
- create vector store id when assistants are created
- allow uploading files when updating assistants
- add migration and tests for vector store updates
- allow removing files from a vector store

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
