### PR TITLE
Handle clearing tools for assistants

### DIFF
--- a/assistants/tests.py
+++ b/assistants/tests.py
@@ -423,3 +423,41 @@ class UpdateVectorStoreTests(TestCase):
         vs_files_delete_mock.assert_called_with(vector_store_id='vs_123', file_id='fileA')
 
 
+class ClearToolsTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+
+    def test_clearing_tools_updates_remote(self):
+        assistant = Assistant.objects.create(
+            name='CT', tools=['file_search'], openai_id='asst_ct', vector_store_id='vs_ct'
+        )
+
+        update_mock = MagicMock()
+
+        class DummyClient:
+            def __init__(self):
+                self.beta = types.SimpleNamespace(assistants=types.SimpleNamespace(update=update_mock))
+
+        dummy_openai = types.SimpleNamespace(OpenAI=lambda api_key=None: DummyClient())
+
+        with patch.dict(sys.modules, {'openai': dummy_openai}):
+            resp = self.client.patch(
+                f'/api/assistants/{assistant.id}/',
+                {'tools': ''},
+                format='multipart'
+            )
+
+        self.assertEqual(resp.status_code, 200)
+        assistant.refresh_from_db()
+        self.assertEqual(assistant.tools, [])
+        update_mock.assert_called_with(
+            assistant.openai_id,
+            name='CT',
+            description='',
+            instructions='',
+            model=assistant.model,
+            tools=[],
+            tool_resources={}
+        )
+
+


### PR DESCRIPTION
## Summary
- sanitize incoming `tools` data for empty strings
- support clearing tools when updating assistants
- clear remote tool settings via OpenAI API
- test clearing tools removes `file_search`

## Testing
- `python manage.py test assistants` *(fails: ModuleNotFoundError: No module named 'django')*