### PR TITLE
Add endpoint to fetch vector store ID

### DIFF
--- a/assistants/tests.py
+++ b/assistants/tests.py
@@ -494,3 +494,19 @@ class ClearToolsTests(TestCase):
         )
 
 
+class VectorStoreIdViewTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+
+    def test_returns_vector_store_id(self):
+        assistant = Assistant.objects.create(name='VS', vector_store_id='vs_1')
+        resp = self.client.get(f'/api/assistants/{assistant.id}/vector-store/')
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()['vector_store_id'], 'vs_1')
+
+    def test_missing_vector_store_returns_404(self):
+        assistant = Assistant.objects.create(name='NoVS')
+        resp = self.client.get(f'/api/assistants/{assistant.id}/vector-store/')
+        self.assertEqual(resp.status_code, 404)
+
+

--- a/assistants/urls.py
+++ b/assistants/urls.py
@@ -1,6 +1,12 @@
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
-from .views import AssistantViewSet, MessageViewSet, ChatView, ResetThreadView
+from .views import (
+    AssistantViewSet,
+    MessageViewSet,
+    ChatView,
+    ResetThreadView,
+    VectorStoreIdView,
+)
 
 router = DefaultRouter()
 router.register('assistants', AssistantViewSet, basename='assistant')
@@ -10,4 +16,9 @@ urlpatterns = [
     path('', include(router.urls)),
     path('assistants/<uuid:pk>/chat/', ChatView.as_view(), name='chat'),
     path('assistants/<uuid:pk>/reset/', ResetThreadView.as_view(), name='reset'),
+    path(
+        'assistants/<uuid:pk>/vector-store/',
+        VectorStoreIdView.as_view(),
+        name='vector-store',
+    ),
 ]

--- a/assistants/views.py
+++ b/assistants/views.py
@@ -308,3 +308,16 @@ class ResetThreadView(APIView):
         assistant.save(update_fields=["thread_id"])
 
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class VectorStoreIdView(APIView):
+    """Return the vector store ID for an assistant."""
+
+    def get(self, request, pk):
+        assistant = get_object_or_404(Assistant, pk=pk)
+        if not assistant.vector_store_id:
+            return Response(
+                {"detail": "No vector store for this assistant."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        return Response({"vector_store_id": assistant.vector_store_id})


### PR DESCRIPTION
## Summary
- add new API endpoint to retrieve an assistant's vector store ID
- wire the endpoint into the URL config
- test the new behavior

## Testing
- `python manage.py test assistants.tests.VectorStoreIdViewTests --verbosity 2` *(fails: ModuleNotFoundError: No module named 'django')*