### PR TITLE
Expose vector store files via API

### DIFF
--- a/assistants/tests.py
+++ b/assistants/tests.py
@@ -510,3 +510,41 @@ class VectorStoreIdViewTests(TestCase):
         self.assertEqual(resp.status_code, 404)
 
 
+class VectorStoreFilesViewTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+
+    def test_lists_files(self):
+        assistant = Assistant.objects.create(name='VS', vector_store_id='vs_1')
+
+        list_mock = MagicMock(return_value=types.SimpleNamespace(data=[
+            {'id': 'file1', 'filename': 'foo.txt'}
+        ]))
+
+        class DummyClient:
+            def __init__(self):
+                self.vector_stores = types.SimpleNamespace(
+                    files=types.SimpleNamespace(list=list_mock)
+                )
+
+        dummy_openai = types.SimpleNamespace(OpenAI=lambda api_key=None: DummyClient())
+
+        with patch.dict(sys.modules, {'openai': dummy_openai}):
+            resp = self.client.get(
+                f'/api/assistants/{assistant.id}/vector-store/files/'
+            )
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json(), [{'id': 'file1', 'filename': 'foo.txt'}])
+        list_mock.assert_called_with(vector_store_id='vs_1')
+
+    def test_missing_vector_store_returns_404(self):
+        assistant = Assistant.objects.create(name='NoVS')
+
+        resp = self.client.get(
+            f'/api/assistants/{assistant.id}/vector-store/files/'
+        )
+
+        self.assertEqual(resp.status_code, 404)
+
+

--- a/assistants/urls.py
+++ b/assistants/urls.py
@@ -6,6 +6,7 @@ from .views import (
     ChatView,
     ResetThreadView,
     VectorStoreIdView,
+    VectorStoreFilesView,
 )
 
 router = DefaultRouter()
@@ -20,5 +21,10 @@ urlpatterns = [
         'assistants/<uuid:pk>/vector-store/',
         VectorStoreIdView.as_view(),
         name='vector-store',
+    ),
+    path(
+        'assistants/<uuid:pk>/vector-store/files/',
+        VectorStoreFilesView.as_view(),
+        name='vector-store-files',
     ),
 ]

--- a/assistants/views.py
+++ b/assistants/views.py
@@ -321,3 +321,22 @@ class VectorStoreIdView(APIView):
                 status=status.HTTP_404_NOT_FOUND,
             )
         return Response({"vector_store_id": assistant.vector_store_id})
+
+
+class VectorStoreFilesView(APIView):
+    """Return the files for an assistant's vector store."""
+
+    def get(self, request, pk):
+        assistant = get_object_or_404(Assistant, pk=pk)
+        if not assistant.vector_store_id:
+            return Response(
+                {"detail": "No vector store for this assistant."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        import openai
+
+        client = openai.OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+        resp = client.vector_stores.files.list(
+            vector_store_id=assistant.vector_store_id
+        )
+        return Response(resp.data)


### PR DESCRIPTION
## Summary
- add `VectorStoreFilesView` that lists OpenAI vector store files
- wire the view in `assistants/urls.py`
- test new endpoint

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*