### PR TITLE
Fix filename retrieval for vector store files

### DIFF
--- a/assistants/tests.py
+++ b/assistants/tests.py
@@ -518,14 +518,16 @@ class VectorStoreFilesViewTests(TestCase):
         assistant = Assistant.objects.create(name='VS', vector_store_id='vs_1')
 
         list_mock = MagicMock(return_value=types.SimpleNamespace(data=[
-            {'id': 'file1', 'filename': 'foo.txt'}
+            {'id': 'file1', 'file_id': 'src_1'}
         ]))
+        retrieve_mock = MagicMock(return_value=types.SimpleNamespace(filename='foo.txt'))
 
         class DummyClient:
             def __init__(self):
                 self.vector_stores = types.SimpleNamespace(
                     files=types.SimpleNamespace(list=list_mock)
                 )
+                self.files = types.SimpleNamespace(retrieve=retrieve_mock)
 
         dummy_openai = types.SimpleNamespace(OpenAI=lambda api_key=None: DummyClient())
 
@@ -537,6 +539,7 @@ class VectorStoreFilesViewTests(TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.json(), [{'id': 'file1', 'filename': 'foo.txt'}])
         list_mock.assert_called_with(vector_store_id='vs_1')
+        retrieve_mock.assert_called_with('src_1')
 
     def test_missing_vector_store_returns_404(self):
         assistant = Assistant.objects.create(name='NoVS')

--- a/assistants/views.py
+++ b/assistants/views.py
@@ -339,4 +339,22 @@ class VectorStoreFilesView(APIView):
         resp = client.vector_stores.files.list(
             vector_store_id=assistant.vector_store_id
         )
-        return Response(resp.data)
+
+        files = []
+        for f in resp.data:
+            file_id = getattr(f, "file_id", None)
+            filename = getattr(f, "filename", None)
+
+            if not filename and file_id:
+                try:
+                    file_info = client.files.retrieve(file_id)
+                    filename = getattr(file_info, "filename", None)
+                except Exception:
+                    filename = None
+
+            files.append({
+                "id": getattr(f, "id", None),
+                "filename": filename,
+            })
+
+        return Response(files)


### PR DESCRIPTION
## Summary
- lookup filenames for files in vector stores
- adjust tests for new filename lookup

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*