### PR TITLE
Fix vector store filename retrieval

### DIFF
--- a/assistants/tests.py
+++ b/assistants/tests.py
@@ -518,7 +518,7 @@ class VectorStoreFilesViewTests(TestCase):
         assistant = Assistant.objects.create(name='VS', vector_store_id='vs_1')
 
         list_mock = MagicMock(return_value=types.SimpleNamespace(data=[
-            {'id': 'file1', 'file_id': 'src_1'}
+            {'id': 'src_1'}
         ]))
         retrieve_mock = MagicMock(return_value=types.SimpleNamespace(filename='foo.txt'))
 
@@ -537,7 +537,7 @@ class VectorStoreFilesViewTests(TestCase):
             )
 
         self.assertEqual(resp.status_code, 200)
-        self.assertEqual(resp.json(), [{'id': 'file1', 'filename': 'foo.txt'}])
+        self.assertEqual(resp.json(), [{'id': 'src_1', 'filename': 'foo.txt'}])
         list_mock.assert_called_with(vector_store_id='vs_1')
         retrieve_mock.assert_called_with('src_1')
 

--- a/assistants/views.py
+++ b/assistants/views.py
@@ -342,7 +342,11 @@ class VectorStoreFilesView(APIView):
 
         files = []
         for f in resp.data:
-            file_id = getattr(f, "file_id", None)
+            # ``vector_stores.files.list`` returns objects that only include
+            # the file ID (``id``). Some older versions of the code expected a
+            # ``file_id`` attribute which isn't present. Use ``id`` as the file
+            # identifier and fetch the filename separately if needed.
+            file_id = getattr(f, "file_id", None) or getattr(f, "id", None)
             filename = getattr(f, "filename", None)
 
             if not filename and file_id:
@@ -353,7 +357,7 @@ class VectorStoreFilesView(APIView):
                     filename = None
 
             files.append({
-                "id": getattr(f, "id", None),
+                "id": file_id,
                 "filename": filename,
             })
 


### PR DESCRIPTION
## Summary
- ensure `vector_stores.files.list` results use `id` when fetching file names
- update tests accordingly

## Testing
- `pytest assistants/tests.py::VectorStoreFilesViewTests::test_lists_files -q` *(fails: ModuleNotFoundError: No module named 'django')*