### PR TITLE
Fix custom user app order

### DIFF
--- a/customgpt_backend/settings.py
+++ b/customgpt_backend/settings.py
@@ -38,6 +38,8 @@ ALLOWED_HOSTS = []
 # Application definition
 
 INSTALLED_APPS = [
+    'org',            # accounts depends on this app
+    'accounts',       # must come before django.contrib.admin
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -46,9 +48,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'rest_framework',
     'assistants',
-    'accounts',
     'users',
-    'org',
 ]
 AUTH_USER_MODEL = 'accounts.User'
 


### PR DESCRIPTION
## Summary
- ensure `accounts` loads before `django.contrib.admin` because we're using a custom user model

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*