### PR TITLE
Fix login error when rotating refresh tokens

### DIFF
--- a/customgpt_backend/settings.py
+++ b/customgpt_backend/settings.py
@@ -46,6 +46,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'rest_framework_simplejwt.token_blacklist',
     'rest_framework',
     'assistants',
     'users',


### PR DESCRIPTION
## Summary
- install SimpleJWT token blacklist app to support rotating refresh tokens

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*