### PR TITLE
Add assistant access model

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Backend
+
+## Assistant permission model
+
+```
+Assistant 1-* AssistantUserAccess
+         1-* AssistantDepartmentAccess
+```
+
+Permissions resolve in the following order:
+`edit` overrides `use`, which overrides no access.

--- a/assistants/admin.py
+++ b/assistants/admin.py
@@ -1,12 +1,35 @@
 from django.contrib import admin
-from .models import Assistant, Message
+from .models import (
+    Assistant,
+    Message,
+    AssistantUserAccess,
+    AssistantDepartmentAccess,
+)
+
+
+class AssistantUserAccessInline(admin.TabularInline):
+    model = AssistantUserAccess
+
+
+class AssistantDepartmentAccessInline(admin.TabularInline):
+    model = AssistantDepartmentAccess
 
 
 @admin.register(Assistant)
 class AssistantAdmin(admin.ModelAdmin):
-    list_display = ("name", "description", "created_at")
+    inlines = [AssistantUserAccessInline, AssistantDepartmentAccessInline]
+    list_display = ("id", "name", "owner")
     readonly_fields = ("openai_id", "thread_id", "created_at")
-    fields = ("name", "description", "instructions", "tools", "openai_id", "thread_id", "created_at")
+    fields = (
+        "name",
+        "owner",
+        "description",
+        "instructions",
+        "tools",
+        "openai_id",
+        "thread_id",
+        "created_at",
+    )
 
 
 @admin.register(Message)

--- a/assistants/managers.py
+++ b/assistants/managers.py
@@ -1,0 +1,11 @@
+from django.db import models
+from django.db.models import Q
+
+
+class AssistantQuerySet(models.QuerySet):
+    def for_user(self, user):
+        q = Q(owner=user) | Q(user_access__user=user)
+        if getattr(user, "department_id", None):
+            q |= Q(dept_access__department_id=user.department_id)
+        return self.filter(q).distinct()
+

--- a/assistants/migrations/0008_assistant_permissions.py
+++ b/assistants/migrations/0008_assistant_permissions.py
@@ -1,0 +1,62 @@
+from django.db import migrations, models
+import django.db.models.deletion
+from django.conf import settings
+
+def set_default_owner(apps, schema_editor):
+    User = apps.get_model('accounts', 'User')
+    Assistant = apps.get_model('assistants', 'Assistant')
+    user = User.objects.first()
+    if not user:
+        user = User.objects.create(username='placeholder')
+    Assistant.objects.filter(owner__isnull=True).update(owner=user)
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('accounts', '0001_initial'),
+        ('org', '0001_initial'),
+        ('assistants', '0007_alter_assistant_model'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='assistant',
+            name='owner',
+            field=models.ForeignKey(
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name='owned_assistants',
+                to=settings.AUTH_USER_MODEL,
+            ),
+        ),
+        migrations.CreateModel(
+            name='AssistantUserAccess',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('permission', models.CharField(max_length=4, choices=[('use', 'Use'), ('edit', 'Edit')])),
+                ('assistant', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='user_access', to='assistants.assistant')),
+                ('user', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='assistant_access', to=settings.AUTH_USER_MODEL)),
+            ],
+            options={'unique_together': {('assistant', 'user')}},
+        ),
+        migrations.CreateModel(
+            name='AssistantDepartmentAccess',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('permission', models.CharField(max_length=4, choices=[('use', 'Use'), ('edit', 'Edit')])),
+                ('assistant', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='dept_access', to='assistants.assistant')),
+                ('department', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='assistant_access', to='org.department')),
+            ],
+            options={'unique_together': {('assistant', 'department')}},
+        ),
+        migrations.RunPython(set_default_owner, migrations.RunPython.noop),
+        migrations.AlterField(
+            model_name='assistant',
+            name='owner',
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name='owned_assistants',
+                to=settings.AUTH_USER_MODEL,
+            ),
+        ),
+    ]

--- a/tests/test_assistant_permissions.py
+++ b/tests/test_assistant_permissions.py
@@ -1,0 +1,55 @@
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+from org.models import Department
+from assistants.models import (
+    Assistant,
+    AssistantUserAccess,
+    AssistantDepartmentAccess,
+    AssistantPermission,
+)
+
+
+class AssistantPermissionTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.dept1 = Department.objects.create(name="Dept1")
+        self.dept2 = Department.objects.create(name="Dept2")
+        self.owner = User.objects.create_user(username="owner", password="pw", department=self.dept1)
+        self.user = User.objects.create_user(username="user", password="pw", department=self.dept1)
+        self.other = User.objects.create_user(username="other", password="pw", department=self.dept2)
+
+    def test_owner_has_edit(self):
+        asst = Assistant.objects.create(name="A", owner=self.owner)
+        self.assertEqual(asst.permission_for(self.owner), AssistantPermission.EDIT)
+
+    def test_user_access_use(self):
+        asst = Assistant.objects.create(name="A", owner=self.owner)
+        AssistantUserAccess.objects.create(assistant=asst, user=self.user, permission=AssistantPermission.USE)
+        self.assertEqual(asst.permission_for(self.user), AssistantPermission.USE)
+
+    def test_department_edit_applies(self):
+        asst = Assistant.objects.create(name="A", owner=self.owner)
+        AssistantDepartmentAccess.objects.create(assistant=asst, department=self.dept2, permission=AssistantPermission.EDIT)
+        self.assertEqual(asst.permission_for(self.other), AssistantPermission.EDIT)
+
+    def test_queryset_for_user(self):
+        owned = Assistant.objects.create(name="Owned", owner=self.owner)
+        user_shared = Assistant.objects.create(name="U", owner=self.owner)
+        dept_shared = Assistant.objects.create(name="D", owner=self.owner)
+        AssistantUserAccess.objects.create(assistant=user_shared, user=self.user, permission=AssistantPermission.USE)
+        AssistantDepartmentAccess.objects.create(assistant=dept_shared, department=self.dept2, permission=AssistantPermission.USE)
+
+        qs_owner = list(Assistant.objects.for_user(self.owner))
+        qs_user = list(Assistant.objects.for_user(self.user))
+        qs_other = list(Assistant.objects.for_user(self.other))
+        self.assertEqual(set(qs_owner), {owned, user_shared, dept_shared})
+        self.assertEqual(qs_user, [user_shared])
+        self.assertEqual(qs_other, [dept_shared])
+
+    def test_unique_constraint(self):
+        asst = Assistant.objects.create(name="A", owner=self.owner)
+        AssistantUserAccess.objects.create(assistant=asst, user=self.user, permission=AssistantPermission.USE)
+        from django.db import IntegrityError
+        with self.assertRaises(IntegrityError):
+            AssistantUserAccess.objects.create(assistant=asst, user=self.user, permission=AssistantPermission.EDIT)
+


### PR DESCRIPTION
## Summary
- add `AssistantPermission` tables and owner FK
- expose query helper `AssistantQuerySet.for_user`
- register permission models in admin
- document assistant permission model
- test assistant permissions

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*