### PR TITLE
Fix assistant creation

### DIFF
--- a/assistants/views.py
+++ b/assistants/views.py
@@ -86,6 +86,7 @@ class AssistantViewSet(viewsets.ModelViewSet):
 
         # 5️⃣  save locally
         serializer.save(
+            owner=self.request.user,
             openai_id=oa_asst.id,
             tools=tools,
             description=data.get("description") or "",


### PR DESCRIPTION
## Summary
- set the assistant owner when saving a new assistant

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*