### PR TITLE
Implement assistant-level permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,22 @@ Assistant 1-* AssistantUserAccess
 
 Permissions resolve in the following order:
 `edit` overrides `use`, which overrides no access.
+
+## Assistant API
+
+All endpoints under `/api/assistants/` require authentication.  The actions
+allowed for a user depend on their permission for each assistant.
+
+| Action (HTTP)       | Who may do it                  |
+|--------------------|--------------------------------|
+| List / Retrieve    | owner, `edit`, or `use`        |
+| Create             | any authenticated user (becomes owner) |
+| Update / Delete    | owner or `edit`                |
+| Chat/Execute       | owner, `edit`, or `use`        |
+
+Example responses when permission checks fail:
+
+```
+GET /api/assistants/<id>/        → 404 Not Found (no access)
+PATCH /api/assistants/<id>/      → 403 Forbidden (only "use")
+```

--- a/assistants/permissions.py
+++ b/assistants/permissions.py
@@ -1,0 +1,13 @@
+from rest_framework.permissions import BasePermission
+
+
+class AssistantPermission(BasePermission):
+    """Object-level permission checks for assistants."""
+
+    def has_object_permission(self, request, view, obj):
+        perm = obj.permission_for(request.user)
+        if view.action in ("retrieve", "execute"):
+            return perm in ("use", "edit") or obj.owner == request.user
+        if view.action in ("update", "partial_update", "destroy"):
+            return perm == "edit" or obj.owner == request.user
+        return False

--- a/assistants/serializers.py
+++ b/assistants/serializers.py
@@ -22,11 +22,13 @@ class AssistantSerializer(serializers.ModelSerializer):
         required=False,
     )
 
+    owner = serializers.SerializerMethodField()
+    permission = serializers.SerializerMethodField()
     messages = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
 
     class Meta:
         model = Assistant
-        fields = ['id', 'name', 'description', 'instructions', 'model', 'reasoning_effort', 'tools', 'created_at', 'messages']
+        fields = ['id', 'name', 'description', 'instructions', 'model', 'reasoning_effort', 'tools', 'created_at', 'owner', 'permission', 'messages']
         read_only_fields = ['id', 'created_at']
 
     def validate_tools(self, value):
@@ -42,3 +44,15 @@ class AssistantSerializer(serializers.ModelSerializer):
             )
 
         return cleaned
+
+    def get_owner(self, obj):
+        request = self.context.get("request")
+        if not request or not request.user:
+            return False
+        return obj.owner_id == request.user.id
+
+    def get_permission(self, obj):
+        request = self.context.get("request")
+        if not request or not request.user:
+            return None
+        return obj.permission_for(request.user)

--- a/assistants/views.py
+++ b/assistants/views.py
@@ -12,6 +12,8 @@ from django.http import JsonResponse
 import time
 from django.shortcuts import get_object_or_404
 from rest_framework import status, viewsets
+from rest_framework.permissions import IsAuthenticated
+from .permissions import AssistantPermission
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from django.utils import timezone
@@ -28,6 +30,10 @@ class AssistantViewSet(viewsets.ModelViewSet):
     """
     queryset = Assistant.objects.all()
     serializer_class = AssistantSerializer
+    permission_classes = [IsAuthenticated, AssistantPermission]
+
+    def get_queryset(self):
+        return Assistant.objects.for_user(self.request.user)
 
     def perform_create(self, serializer):
         import openai
@@ -86,6 +92,7 @@ class AssistantViewSet(viewsets.ModelViewSet):
 
         # 5️⃣  save locally
         serializer.save(
+            owner=self.request.user,
             openai_id=oa_asst.id,
             tools=tools,
             description=data.get("description") or "",
@@ -246,8 +253,12 @@ class ChatView(APIView):
     Body: {"content": "..."}
     """
 
+    permission_classes = [IsAuthenticated, AssistantPermission]
+
     def post(self, request, pk):
         assistant = get_object_or_404(Assistant, pk=pk)
+        self.action = "execute"
+        self.check_object_permissions(request, assistant)
         user_msg  = request.data.get("content", "").strip()
         if not user_msg:
             return Response({"detail": "`content` field is required"},
@@ -312,9 +323,12 @@ class ChatView(APIView):
 
 class ResetThreadView(APIView):
     """Delete all messages and remote thread for an assistant."""
+    permission_classes = [IsAuthenticated, AssistantPermission]
 
     def post(self, request, pk):
         assistant = get_object_or_404(Assistant, pk=pk)
+        self.action = "execute"
+        self.check_object_permissions(request, assistant)
         thread_id = assistant.thread_id
 
         if thread_id:
@@ -334,9 +348,12 @@ class ResetThreadView(APIView):
 
 class VectorStoreIdView(APIView):
     """Return the vector store ID for an assistant."""
+    permission_classes = [IsAuthenticated, AssistantPermission]
 
     def get(self, request, pk):
         assistant = get_object_or_404(Assistant, pk=pk)
+        self.action = "retrieve"
+        self.check_object_permissions(request, assistant)
         if not assistant.vector_store_id:
             return Response(
                 {"detail": "No vector store for this assistant."},
@@ -347,9 +364,12 @@ class VectorStoreIdView(APIView):
 
 class VectorStoreFilesView(APIView):
     """Return the files for an assistant's vector store."""
+    permission_classes = [IsAuthenticated, AssistantPermission]
 
     def get(self, request, pk):
         assistant = get_object_or_404(Assistant, pk=pk)
+        self.action = "retrieve"
+        self.check_object_permissions(request, assistant)
         if not assistant.vector_store_id:
             return Response(
                 {"detail": "No vector store for this assistant."},
@@ -388,9 +408,12 @@ class VectorStoreFilesView(APIView):
 
 class VectorStoreFileView(APIView):
     """Delete a single file from an assistant's vector store."""
+    permission_classes = [IsAuthenticated, AssistantPermission]
 
     def delete(self, request, pk, file_id):
         assistant = get_object_or_404(Assistant, pk=pk)
+        self.action = "destroy"
+        self.check_object_permissions(request, assistant)
         if not assistant.vector_store_id:
             return Response(
                 {"detail": "No vector store for this assistant."},

--- a/tests/test_assistant_api.py
+++ b/tests/test_assistant_api.py
@@ -1,0 +1,120 @@
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+from rest_framework.test import APIClient
+from org.models import Department
+from assistants.models import Assistant, AssistantUserAccess, AssistantPermission
+from unittest.mock import MagicMock, patch
+import types
+import sys
+
+
+class AssistantAPITests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        User = get_user_model()
+        self.dept = Department.objects.create(name="Dept")
+        self.owner1 = User.objects.create_user(username="owner1", password="pw", department=self.dept)
+        self.owner2 = User.objects.create_user(username="owner2", password="pw", department=self.dept)
+        self.use_user = User.objects.create_user(username="use", password="pw", department=self.dept)
+        self.edit_user = User.objects.create_user(username="edit", password="pw", department=self.dept)
+        self.other = User.objects.create_user(username="other", password="pw", department=self.dept)
+
+        self.asst1 = Assistant.objects.create(name="A1", owner=self.owner1)
+        self.asst2 = Assistant.objects.create(name="A2", owner=self.owner2)
+        AssistantUserAccess.objects.create(
+            assistant=self.asst2,
+            user=self.use_user,
+            permission=AssistantPermission.USE,
+        )
+        AssistantUserAccess.objects.create(
+            assistant=self.asst2,
+            user=self.edit_user,
+            permission=AssistantPermission.EDIT,
+        )
+
+    def _auth(self, user):
+        resp = self.client.post(
+            "/api/token/",
+            {"username": user.username, "password": "pw"},
+            format="json",
+        )
+        token = resp.json()["access"]
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {token}")
+
+    def test_list_filtered(self):
+        self._auth(self.owner1)
+        resp = self.client.get("/api/assistants/")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(len(resp.json()), 1)
+        self.assertEqual(resp.json()[0]["id"], str(self.asst1.id))
+
+        self._auth(self.use_user)
+        resp = self.client.get("/api/assistants/")
+        self.assertEqual(len(resp.json()), 1)
+        self.assertEqual(resp.json()[0]["id"], str(self.asst2.id))
+
+        self._auth(self.other)
+        resp = self.client.get("/api/assistants/")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json(), [])
+
+    def test_retrieve_denied_without_access(self):
+        self._auth(self.other)
+        resp = self.client.get(f"/api/assistants/{self.asst1.id}/")
+        self.assertEqual(resp.status_code, 404)
+
+    def test_update_denied_with_use_only(self):
+        self._auth(self.use_user)
+        dummy_openai = types.SimpleNamespace(OpenAI=lambda api_key=None: MagicMock())
+        with patch.dict(sys.modules, {"openai": dummy_openai}):
+            resp = self.client.patch(
+                f"/api/assistants/{self.asst2.id}/",
+                {"name": "X"},
+                format="json",
+            )
+        self.assertEqual(resp.status_code, 403)
+
+    def test_update_allowed_for_edit(self):
+        self._auth(self.edit_user)
+        update_mock = MagicMock()
+
+        class DummyClient:
+            def __init__(self):
+                self.beta = types.SimpleNamespace(assistants=types.SimpleNamespace(update=update_mock))
+
+        dummy_openai = types.SimpleNamespace(OpenAI=lambda api_key=None: DummyClient())
+        with patch.dict(sys.modules, {"openai": dummy_openai}):
+            resp = self.client.patch(
+                f"/api/assistants/{self.asst2.id}/",
+                {"name": "New"},
+                format="json",
+            )
+        self.assertEqual(resp.status_code, 200)
+        self.asst2.refresh_from_db()
+        self.assertEqual(self.asst2.name, "New")
+
+    def test_execute_allowed_for_use(self):
+        self._auth(self.use_user)
+        message = types.SimpleNamespace(content=[types.SimpleNamespace(text=types.SimpleNamespace(value="hi"))])
+
+        class DummyClient:
+            def __init__(self):
+                self.beta = types.SimpleNamespace(
+                    threads=types.SimpleNamespace(
+                        create=lambda: types.SimpleNamespace(id="t1"),
+                        messages=types.SimpleNamespace(create=lambda **kwargs: None, list=lambda **kwargs: types.SimpleNamespace(data=[message])),
+                        runs=types.SimpleNamespace(create=lambda **kwargs: types.SimpleNamespace(id="r1", status="completed"), retrieve=lambda **kwargs: types.SimpleNamespace(id="r1", status="completed")),
+                    )
+                )
+        dummy_openai = types.SimpleNamespace(OpenAI=lambda api_key=None: DummyClient())
+        with patch.dict(sys.modules, {"openai": dummy_openai}):
+            resp = self.client.post(
+                f"/api/assistants/{self.asst2.id}/chat/",
+                {"content": "hi"},
+                format="json",
+            )
+        self.assertEqual(resp.status_code, 200)
+
+    def test_anonymous_blocked(self):
+        resp = self.client.get("/api/assistants/")
+        self.assertEqual(resp.status_code, 401)


### PR DESCRIPTION
## Summary
- enforce permissions for assistant APIs
- add AssistantPermission permission class
- augment assistant serializers with owner and permission fields
- update docs with Assistant API permission table
- test access rules for assistant endpoints

## Testing
- `pytest -q` *(fails: Could not find a version that satisfies the requirement django)*