### PR TITLE
Implement assistant sharing API

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,16 @@ Example responses when permission checks fail:
 GET /api/assistants/<id>/        → 404 Not Found (no access)
 PATCH /api/assistants/<id>/      → 403 Forbidden (only "use")
 ```
+
+## Sharing API
+
+Owners (or admins) can share assistants with individual users or entire departments.
+
+```
+POST /api/assistants/<id>/shares/users/ {"user": 5, "permission": "use"}
+POST /api/assistants/<id>/shares/users/ {"user": 5, "permission": "edit"}  # update
+DELETE /api/assistants/<id>/shares/users/5/
+```
+
+Department sharing works the same using the `shares/departments/` routes.
+

--- a/assistants/serializers.py
+++ b/assistants/serializers.py
@@ -1,5 +1,12 @@
 from rest_framework import serializers
-from .models import Assistant, Message, ALLOWED_MODELS, REASONING_EFFORT_CHOICES
+from .models import (
+    Assistant,
+    Message,
+    AssistantUserAccess,
+    AssistantDepartmentAccess,
+    ALLOWED_MODELS,
+    REASONING_EFFORT_CHOICES,
+)
 
 
 class MessageSerializer(serializers.ModelSerializer):
@@ -56,3 +63,15 @@ class AssistantSerializer(serializers.ModelSerializer):
         if not request or not request.user:
             return None
         return obj.permission_for(request.user)
+
+
+class AssistantShareUserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = AssistantUserAccess
+        fields = ("user", "permission")
+
+
+class AssistantShareDeptSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = AssistantDepartmentAccess
+        fields = ("department", "permission")

--- a/assistants/urls.py
+++ b/assistants/urls.py
@@ -1,5 +1,6 @@
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
+from rest_framework_nested import routers
 from .views import (
     AssistantViewSet,
     MessageViewSet,
@@ -8,14 +9,21 @@ from .views import (
     VectorStoreIdView,
     VectorStoreFilesView,
     VectorStoreFileView,
+    AssistantUserShareViewSet,
+    AssistantDeptShareViewSet,
 )
 
 router = DefaultRouter()
 router.register('assistants', AssistantViewSet, basename='assistant')
 router.register('messages',   MessageViewSet,   basename='message')
 
+assistant_router = routers.NestedDefaultRouter(router, 'assistants', lookup='assistant')
+assistant_router.register('shares/users', AssistantUserShareViewSet, basename='assistant-user-share')
+assistant_router.register('shares/departments', AssistantDeptShareViewSet, basename='assistant-dept-share')
+
 urlpatterns = [
     path('', include(router.urls)),
+    path('', include(assistant_router.urls)),
     path('assistants/<uuid:pk>/chat/', ChatView.as_view(), name='chat'),
     path('assistants/<uuid:pk>/reset/', ResetThreadView.as_view(), name='reset'),
     path(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 djangorestframework-simplejwt==5.5.0
+drf-nested-routers

--- a/tests/test_sharing_api.py
+++ b/tests/test_sharing_api.py
@@ -1,0 +1,103 @@
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+from rest_framework.test import APIClient
+from org.models import Department
+from assistants.models import Assistant, AssistantUserAccess, AssistantDepartmentAccess, AssistantPermission
+
+class AssistantSharingAPITests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        User = get_user_model()
+        self.sales = Department.objects.create(name="Sales")
+        self.support = Department.objects.create(name="Support")
+        self.owner = User.objects.create_user(username="owner", password="pw", department=self.sales)
+        self.other = User.objects.create_user(username="other", password="pw", department=self.support)
+        self.third = User.objects.create_user(username="third", password="pw", department=self.support)
+        self.asst = Assistant.objects.create(name="Share", owner=self.owner)
+
+    def _auth(self, user):
+        resp = self.client.post(
+            "/api/token/",
+            {"username": user.username, "password": "pw"},
+            format="json",
+        )
+        token = resp.json()["access"]
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {token}")
+
+    def test_owner_can_add_user_share(self):
+        self._auth(self.owner)
+        resp = self.client.post(
+            f"/api/assistants/{self.asst.id}/shares/users/",
+            {"user": self.other.id, "permission": "use"},
+            format="json",
+        )
+        self.assertEqual(resp.status_code, 201)
+        self.assertTrue(
+            AssistantUserAccess.objects.filter(
+                assistant=self.asst, user=self.other, permission=AssistantPermission.USE
+            ).exists()
+        )
+
+    def test_repost_updates_permission(self):
+        AssistantUserAccess.objects.create(
+            assistant=self.asst, user=self.other, permission=AssistantPermission.USE
+        )
+        self._auth(self.owner)
+        resp = self.client.post(
+            f"/api/assistants/{self.asst.id}/shares/users/",
+            {"user": self.other.id, "permission": "edit"},
+            format="json",
+        )
+        self.assertEqual(resp.status_code, 200)
+        access = AssistantUserAccess.objects.get(assistant=self.asst, user=self.other)
+        self.assertEqual(access.permission, AssistantPermission.EDIT)
+
+    def test_non_owner_forbidden(self):
+        self._auth(self.other)
+        resp = self.client.post(
+            f"/api/assistants/{self.asst.id}/shares/users/",
+            {"user": self.third.id, "permission": "use"},
+            format="json",
+        )
+        self.assertEqual(resp.status_code, 403)
+
+    def test_owner_can_remove_user(self):
+        AssistantUserAccess.objects.create(
+            assistant=self.asst, user=self.other, permission=AssistantPermission.USE
+        )
+        self._auth(self.owner)
+        resp = self.client.delete(
+            f"/api/assistants/{self.asst.id}/shares/users/{self.other.id}/"
+        )
+        self.assertEqual(resp.status_code, 204)
+        self.assertFalse(
+            AssistantUserAccess.objects.filter(assistant=self.asst, user=self.other).exists()
+        )
+        self._auth(self.other)
+        resp = self.client.get("/api/assistants/")
+        self.assertEqual(resp.json(), [])
+
+    def test_department_share_applies_to_new_user(self):
+        self._auth(self.owner)
+        resp = self.client.post(
+            f"/api/assistants/{self.asst.id}/shares/departments/",
+            {"department": self.support.id, "permission": "use"},
+            format="json",
+        )
+        self.assertEqual(resp.status_code, 201)
+        new_user = get_user_model().objects.create_user(
+            username="new", password="pw", department=self.support
+        )
+        self._auth(new_user)
+        resp = self.client.get("/api/assistants/")
+        ids = [a["id"] for a in resp.json()]
+        self.assertIn(str(self.asst.id), ids)
+
+    def test_owner_cannot_remove_self(self):
+        self._auth(self.owner)
+        resp = self.client.delete(
+            f"/api/assistants/{self.asst.id}/shares/users/{self.owner.id}/"
+        )
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("Owner", resp.json().get("detail", ""))
+


### PR DESCRIPTION
## Summary
- add drf-nested-routers dependency
- implement serializers for sharing
- add sharing mixin and share viewsets
- wire up nested routes
- document Sharing API
- add tests for sharing logic

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*