### PR TITLE
Fix missing nested router

### DIFF
--- a/assistants/urls.py
+++ b/assistants/urls.py
@@ -1,6 +1,5 @@
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
-from rest_framework_nested import routers
 from .views import (
     AssistantViewSet,
     MessageViewSet,
@@ -17,13 +16,28 @@ router = DefaultRouter()
 router.register('assistants', AssistantViewSet, basename='assistant')
 router.register('messages',   MessageViewSet,   basename='message')
 
-assistant_router = routers.NestedDefaultRouter(router, 'assistants', lookup='assistant')
-assistant_router.register('shares/users', AssistantUserShareViewSet, basename='assistant-user-share')
-assistant_router.register('shares/departments', AssistantDeptShareViewSet, basename='assistant-dept-share')
+user_share_list = AssistantUserShareViewSet.as_view({
+    'get': 'list',
+    'post': 'create',
+})
+user_share_detail = AssistantUserShareViewSet.as_view({
+    'delete': 'destroy',
+})
+
+dept_share_list = AssistantDeptShareViewSet.as_view({
+    'get': 'list',
+    'post': 'create',
+})
+dept_share_detail = AssistantDeptShareViewSet.as_view({
+    'delete': 'destroy',
+})
 
 urlpatterns = [
     path('', include(router.urls)),
-    path('', include(assistant_router.urls)),
+    path('assistants/<uuid:assistant_pk>/shares/users/', user_share_list, name='assistant-user-share-list'),
+    path('assistants/<uuid:assistant_pk>/shares/users/<int:pk>/', user_share_detail, name='assistant-user-share-detail'),
+    path('assistants/<uuid:assistant_pk>/shares/departments/', dept_share_list, name='assistant-dept-share-list'),
+    path('assistants/<uuid:assistant_pk>/shares/departments/<int:pk>/', dept_share_detail, name='assistant-dept-share-detail'),
     path('assistants/<uuid:pk>/chat/', ChatView.as_view(), name='chat'),
     path('assistants/<uuid:pk>/reset/', ResetThreadView.as_view(), name='reset'),
     path(
@@ -42,3 +56,4 @@ urlpatterns = [
         name='vector-store-file',
     ),
 ]
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 djangorestframework-simplejwt==5.5.0
-drf-nested-routers
+djangorestframework


### PR DESCRIPTION
## Summary
- drop use of `rest_framework_nested`
- simplify share endpoints with manual paths
- remove `drf-nested-routers` dependency
- add `djangorestframework` to requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*